### PR TITLE
Don't throw an exception if the LocalDate parse fails

### DIFF
--- a/src/main/java/name/velikodniy/vitaliy/fixedlength/formatters/LocalDateFormatter.java
+++ b/src/main/java/name/velikodniy/vitaliy/fixedlength/formatters/LocalDateFormatter.java
@@ -4,6 +4,7 @@ import name.velikodniy.vitaliy.fixedlength.annotation.FixedField;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 public class LocalDateFormatter extends Formatter<LocalDate> {
 
@@ -15,7 +16,11 @@ public class LocalDateFormatter extends Formatter<LocalDate> {
 
     @Override
     public LocalDate asObject(String string, FixedField field) {
-        return LocalDate.parse(string, format(field));
+        try {
+            return LocalDate.parse(string, format(field));
+        } catch (DateTimeParseException e) {
+            return null;
+        }
     }
 
     @Override

--- a/src/test/java/FormatterTest.java
+++ b/src/test/java/FormatterTest.java
@@ -12,6 +12,8 @@ class FormatterTest {
     String singleTypeExample =
             "Joe1      Smith     Developer 07500010012009\n" +
             "Joe3      Smith     Developer ";
+    String badLocalDateExample =
+            "Joe1      Smith     Developer 07500015012009";
 
     @Test
     @DisplayName("Simple string format")
@@ -25,6 +27,21 @@ class FormatterTest {
 
         assertEquals(singleTypeExample, impl.format(parse));
 
+    }
+
+    @Test
+    @DisplayName("Bad Local Date")
+    void badLocalDate() {
+
+        FixedLength<Row> impl = new FixedLength<Row>()
+                .registerLineType(Employee.class);
+
+        List<Row> parse = impl
+                .parse(new ByteArrayInputStream(badLocalDateExample.getBytes()));
+
+        Employee employee = (Employee) parse.get(0);
+
+        assertEquals(employee.hireDate, null);
     }
 
 }


### PR DESCRIPTION
If a LocalDate is in an invalid format, the entire parsing fails due to an exception being thrown. This is an issue for systems that just continue on if the LocalDate is in an invalid format.